### PR TITLE
✨ Add a new rule about controlled_access

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ See `python main.py --help` for details.
 * root_phs_acl: f"{study_phs}.c999" (This gives root access to the study)
 * consent_acl: f"{study_phs}.c{code}" (Not c999 which is a reserved admin code)
 * default_acl: [study_kfid, root_phs_acl]
+* open_acl: ["*"]
 
 ## ACL Rules
 
@@ -42,25 +43,30 @@ See `python main.py --help` for details.
   dataservice, **return or display an alert**.
 
 * Dataservice biospecimens whose samples are found in the sample status file
-  with status "Loaded" should have their consent_type dbgap_consent_code fields
-  set as indicated in the file.
+  with status "Loaded" should have their `consent_type` and
+  `dbgap_consent_code` fields set as indicated in the file.
 
 * All other dataservice biospecimens should be hidden in the dataservice and
-  their `"consent_type"` and `"dbgap_consent_code"` fields should be set to
+  their `consent_type` and `dbgap_consent_code` fields should be set to
   `null`.
 
-    * If a biospecimen is hidden in the dataservice, its descendants (genomic
-      files, read groups, etc) should also be hidden.
+* If a biospecimen is hidden in the dataservice, its descendants (genomic
+  files, read groups, etc) should also be hidden.
 
-* All genomic files in the dataservice should get `{default_acl}`.
+* All non-hidden (aka visible) genomic files in the dataservice with their
+  `controlled_access` field set to **False** or **null** should get
+  `{open_acl}`.
 
-* Each reported custom consent code should be added to each genomic file with
-  contribution from any biospecimen(s) in the study with the reported sample
-  external ID by adding the `{consent_acl}` in addition to the default **IF AND
-  ONLY IF** the genomic file and its contributing biospecimen(s) are all
-  visible in the dataservice, **with the following exception:**
+* All other genomic files in the dataservice should get `{default_acl}`.
 
-    * Until indexd supports "and" composition rules, if a genomic file has
-      multiple contributing specimens with non-identical access control codes,
-      that genomic file should get `{default_acl}`. **Return or display an
-      alert for each such case.**
+* Each reported sample consent code should be added to each
+  `controlled_access=True` genomic file that has contribution from any
+  biospecimen(s) in the study with the reported sample external ID by adding
+  the `{consent_acl}` in addition to the default **IF AND ONLY IF** the genomic
+  file and its contributing biospecimen(s) are all visible in the dataservice,
+  **with the following exception:**
+
+  * Until indexd supports "and" composition rules, if a genomic file has
+    multiple contributing specimens with non-identical access control codes,
+    that genomic file should get `{default_acl}`. **Return or display an
+    alert for each such case.**

--- a/tests/data/phs999999_dataservice.json
+++ b/tests/data/phs999999_dataservice.json
@@ -59,11 +59,17 @@
         }
     },
     "genomic-files": {
-        "GF_11111111": {"hashes": {}, "size": 0, "urls": []},
-        "GF_22222222": {"hashes": {}, "size": 0, "urls": []},
-        "GF_33333333": {"hashes": {}, "size": 0, "urls": []}
+        "GF_00000000": {"hashes": {}, "size": 1, "urls": [], "controlled_access": false},
+        "GF_11111111": {"hashes": {}, "size": 1, "urls": [], "controlled_access": true},
+        "GF_22222222": {"hashes": {}, "size": 1, "urls": [], "controlled_access": true},
+        "GF_33333333": {"hashes": {}, "size": 1, "urls": [], "controlled_access": true},
+        "GF_44444444": {"hashes": {}, "size": 1, "urls": [], "controlled_access": false}
     },
     "biospecimen-genomic-files": {
+        "BG_00000000": {
+            "biospecimen_id": "BS_11111111",
+            "genomic_file_id": "GF_00000000"
+        },
         "BG_11111111": {
             "biospecimen_id": "BS_11111111",
             "genomic_file_id": "GF_11111111"
@@ -75,6 +81,10 @@
         "BG_33333333": {
             "biospecimen_id": "BS_33333333",
             "genomic_file_id": "GF_33333333"
+        },
+        "BG_44444444": {
+            "biospecimen_id": "BS_33333333",
+            "genomic_file_id": "GF_44444444"
         }
     },
     "sequencing-experiments": {
@@ -92,6 +102,10 @@
         }
     },
     "sequencing-experiment-genomic-files": {
+        "SG_00000000": {
+            "sequencing_experiment_id": "SE_11111111",
+            "genomic_file_id": "GF_00000000"
+        },
         "SG_11111111": {
             "sequencing_experiment_id": "SE_11111111",
             "genomic_file_id": "GF_11111111"
@@ -103,6 +117,10 @@
         "SG_33333333": {
             "sequencing_experiment_id": "SE_33333333",
             "genomic_file_id": "GF_33333333"
+        },
+        "SG_44444444": {
+            "sequencing_experiment_id": "SE_33333333",
+            "genomic_file_id": "GF_44444444"
         }
     }
 }

--- a/tests/data/phs999999_patches.json
+++ b/tests/data/phs999999_patches.json
@@ -5,6 +5,9 @@
         }
     },
     "biospecimen-genomic-files": {
+        "BG_00000000": {
+            "visible": false
+        },
         "BG_11111111": {
             "visible": false
         }
@@ -23,6 +26,13 @@
         }
     },
     "genomic-files": {
+        "GF_00000000": {
+            "acl": [
+                "SD_00000000",
+                "phs999999.c999"
+            ],
+            "visible": false
+        },
         "GF_11111111": {
             "acl": [
                 "SD_00000000",
@@ -43,9 +53,15 @@
                 "phs999999.c2",
                 "phs999999.c999"
             ]
+        },
+        "GF_44444444": {
+            "acl": ["*"]
         }
     },
     "sequencing-experiment-genomic-files": {
+        "SG_00000000": {
+            "visible": false
+        },
         "SG_11111111": {
             "visible": false
         }


### PR DESCRIPTION
All non-hidden (aka visible) genomic files in the dataservice with their `controlled_access` field set to **False** or **null** should get `{open_acl}`.