### PR TITLE
✨ Add ability to set things to be visible if loaded in dbgap

### DIFF
--- a/kf_update_dbgap_consent/app/cli.py
+++ b/kf_update_dbgap_consent/app/cli.py
@@ -3,8 +3,8 @@ import argparse
 from argparse import RawTextHelpFormatter
 from pprint import pprint
 
-from kf_utils.dataservice.patch import send_patches
 from kf_update_dbgap_consent.sample_status import ConsentProcessor
+from kf_utils.dataservice.patch import send_patches
 
 SERVER_DEFAULT = "http://localhost:5000"
 
@@ -46,12 +46,25 @@ def cli():
             " - Defaults to match on `external_sample_id`"
         ),
     )
+    parser.add_argument(
+        "--coerce_visible",
+        action="store_true",
+        default=False,
+        help=(
+            "If a specimen is loaded into dbgap, set the specimens, its "
+            "descendants, and the associated participant to visible."
+        ),
+    )
     args = parser.parse_args()
     print(f"Args: {args.__dict__}")
 
     patches, alerts = ConsentProcessor(
         args.server, args.db_url
-    ).get_patches_for_study(args.study, match_aliquot=args.match_aliquot)
+    ).get_patches_for_study(
+        args.study,
+        match_aliquot=args.match_aliquot,
+        coerce_visible=args.coerce_visible,
+    )
 
     all_patches = {}
     for endpoint_patches in patches.values():

--- a/kf_update_dbgap_consent/app/cli.py
+++ b/kf_update_dbgap_consent/app/cli.py
@@ -51,7 +51,7 @@ def cli():
         action="store_true",
         default=False,
         help=(
-            "If a specimen is loaded into dbgap, set the specimens, its "
+            "If a specimen is loaded into dbgap, set the specimen, its "
             "descendants, and the associated participant to visible."
         ),
     )

--- a/kf_update_dbgap_consent/app/cli.py
+++ b/kf_update_dbgap_consent/app/cli.py
@@ -52,7 +52,8 @@ def cli():
         default=False,
         help=(
             "If a specimen is loaded into dbgap, set the specimen, its "
-            "descendants, and the associated participant to visible."
+            "descendants, the associated participant, and the associated "
+            "participant's non-specimen descendants to visible."
         ),
     )
     args = parser.parse_args()

--- a/kf_update_dbgap_consent/sample_status.py
+++ b/kf_update_dbgap_consent/sample_status.py
@@ -233,8 +233,8 @@ class ConsentProcessor:
                     unhidden_specimens[kfid] = bs
             descendants_of_unhidden_specimens = find_descendants_by_kfids(
                 self.db_url or self.api_url,
-                "biospecimens",
-                list(unhidden_specimens.keys()),
+                "participants",
+                [bs["participant_id"] for bs in unhidden_specimens.values()],
                 ignore_gfs_with_hidden_external_contribs=False,
                 kfids_only=False,
             )
@@ -248,9 +248,7 @@ class ConsentProcessor:
                     ],
                 )
             }
-            descendants_of_unhidden_specimens[
-                "biospecimens"
-            ] = unhidden_specimens
+            breakpoint()
             for (
                 endpoint,
                 entities,


### PR DESCRIPTION
see https://github.com/kids-first/kf-update-dbgap-consent/issues/18

I added a flag to dbgapconsent so that every sample that is loaded in dbgap for a particular study (along with descendants and associated participants) be set to be visible in the dataservice. 